### PR TITLE
 Allow OPTIONS through without authenticating. 

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -39,7 +39,7 @@ class BaseHandler(webapp2.RequestHandler):
       self.user.put()
 
   def dispatch(self):
-    if not self.user:
+    if not self.user and self.request.method != 'OPTIONS':
       return self.redirect(users.create_login_url(self.request.path))
     super(BaseHandler, self).dispatch()
 


### PR DESCRIPTION
Firefox at least sends cookies only on the real request, not on the CORS OPTIONS request.

Tested this one on my own test app in appspot now that it failed once.  Works there.
