### PR TITLE
Update server/mail.py

### DIFF
--- a/server/mail.py
+++ b/server/mail.py
@@ -22,7 +22,7 @@ class Handler(mail_handlers.InboundMailHandler):
   """Incoming mail handler."""
 
   def receive(self, mail_message):
-    if 'Gmail Forwarding Confirmation' in mail_message.subject:
+    if 'Forwarding Confirmation' in mail_message.subject:
       logging.info('Received Gmail forwarding request')
       for _content_type, body in mail_message.bodies('text/plain'):
         decoded_body = body.decode()


### PR DESCRIPTION
Removed "Gmail" from the match requirement for forwarding confirmation.  This is to enable gmail users with their own domains to participate.  

For reference this is what an email forwarding request looks like from gmail from a different domain.

Subject: (#43643746) Emarf.net Forwarding Confirmation - Receive Mail from dave@emarf.net
