### PR TITLE
Strip portal names in xmpp messages

### DIFF
--- a/server/mail.py
+++ b/server/mail.py
@@ -63,7 +63,7 @@ def send_message(users, portal, url):
       user.email for user in users
       if memcache.add('%s|||%s' % (portal_keyname, user.email), 1, time=120)]
   if emails:
-    msg = 'Alert! *%s* (%s) is under attack! %s' % (portal.title, portal.address, url)
+    msg = 'Alert! *%s* (%s) is under attack! %s' % (portal.title.strip(), portal.address, url)
     xmpp.send_message(emails, msg)
 
 


### PR DESCRIPTION
I received an alert from ingress-notify that looked like this:

ingress-notify:  Alert! *A Riot, the Massacre, and the \* (59-99 Tremont Street, Boston, MA 02108, USA) is under attack! http://www.ingress.com/intel?latE6=42357440&lngE6=-71061147&z=19
 Sent at 5:18 PM on Tuesday

The asterisks usually bold the portal name, but did not in this case because of the trailing whitespace.
